### PR TITLE
FIX 当段落长度超过最大长度时，处理分块逻辑重复

### DIFF
--- a/docs/chapter7/RAG/utils.py
+++ b/docs/chapter7/RAG/utils.py
@@ -84,10 +84,10 @@ class ReadFiles:
                             break
                     curr_chunk = curr_chunk[-cover_content:] + line[start:end]
                     chunk_text.append(curr_chunk)
-                # 处理最后一个块
-                start = (num_chunks - 1) * token_len
-                curr_chunk = curr_chunk[-cover_content:] + line[start:end]
-                chunk_text.append(curr_chunk)
+                # # 处理最后一个块
+                # start = (num_chunks - 1) * token_len
+                # curr_chunk = curr_chunk[-cover_content:] + line[start:end]
+                # chunk_text.append(curr_chunk)
                 
             if curr_len + line_len <= token_len:
                 curr_chunk += line


### PR DESCRIPTION
<img width="563" alt="Snipaste_2025-07-02_18-00-54" src="https://github.com/user-attachments/assets/9b9b6527-939c-4335-9fda-d0809cc235b0" />
处理长度超过最大长度的句子分块时，最后一块的逻辑重复了，(line_len + token_len - 1) // token_len 这边已经上取整，所以最后一块已经包含在里面了