### PR TITLE
更改第五章段落序号错误

### DIFF
--- a/docs/chapter5/第五章 动手搭建大模型.md
+++ b/docs/chapter5/第五章 动手搭建大模型.md
@@ -661,7 +661,7 @@ torch.Size([1, 1, 6144])
 
 在自然语言处理 (NLP) 中，Tokenizer 是一种将文本分解为较小单位（称为 token）的工具。这些 token 可以是词、子词、字符，甚至是特定的符号。Tokenization 是 NLP 中的第一步，直接影响后续处理和分析的效果。不同类型的 tokenizer 适用于不同的应用场景，以下是几种常见的 tokenizer 及其特点。
 
-### 5.3.1 Word-based Tokenizer
+### 5.2.1 Word-based Tokenizer
 
 **Word-based Tokenizer** 是最简单和直观的一种分词方法。它将文本按空格和标点符号分割成单词。这种方法的优点在于其简单和直接，易于实现，且与人类对语言的直觉相符。然而，它也存在一些明显的缺点，如无法处理未登录词（OOV，out-of-vocabulary）和罕见词，对复合词（如“New York”）或缩略词（如“don't”）的处理也不够精细。此外，Word-based Tokenizer 在处理不同语言时也会遇到挑战，因为一些语言（如中文、日文）没有显式的单词分隔符。
 

--- a/docs/chapter5/第五章 动手搭建大模型.md
+++ b/docs/chapter5/第五章 动手搭建大模型.md
@@ -990,7 +990,7 @@ Special tokens preserved: False
 
 在前面的章节中，我们熟悉了各种大模型的模型结构，以及如如何训练Tokenizer。在本节中，我们将动手训练一个八千万参数的LLM。
 
-### 5.3.0 数据下载
+### 5.3.1 数据下载
 
 首先，我们需要下载预训练数据集。在这里，我们使用两个开源的数据集，包含了大量的中文对话数据，可以用于训练对话生成模型。
 
@@ -1052,7 +1052,7 @@ with open('BelleGroup_sft.jsonl', 'a', encoding='utf-8') as sft:
             sft.write(json.dumps(message, ensure_ascii=False) + '\n')
 ```
 
-### 5.3.1 训练Tokenize
+### 5.3.2 训练Tokenize
 
 首先，我们需要为文本处理训练一个Tokenizer。Tokenizer的作用是将文本转换为数字序列，以便模型能够理解和处理。我们使用的数据集是 [出门问问序列猴子开源数据集](https://www.modelscope.cn/datasets/ddzhu123/seq-monkey/files) ，这个数据集包含了大量的中文文本数据，可以用于训练Tokenizer。
 
@@ -1289,7 +1289,7 @@ Hello<|im_end|>
 Special tokens preserved: False
 ```
 
-### 5.3.2 Dataset
+### 5.3.3 Dataset
 
 #### PretrainDataset
 
@@ -1426,7 +1426,7 @@ class SFTDataset(Dataset):
 可以看到，其实 SFT Dataset 和 Pretrain Dataset 的 `X` 和 `Y` 是一样的，只是在 SFT Dataset 中我们需要生成一个 `loss_mask` 来标记哪些位置需要计算损失，哪些位置不需要计算损失。 图中 `Input ids` 中的蓝色小方格就是AI的回答，所以是需要模型学习的地方。所以在 `loss_mask` 中，蓝色小方格对应的位置是黄色，其他位置是灰色。在代码 `loss_mask` 中的 1 对应的位置计算损失，0 对应的位置不计算损失。
 
 
-### 5.3.3 预训练
+### 5.3.4 预训练
 
 在数据预处理完成后，我们就可以开始训练模型了。我们使用的模型是一个和LLama2结构一样的 Decoder only Transformer模型，使用Pytorch实现。相关代码在`code/k_model.py`文件中。此处不再赘述，源码中有详细的中文注释，且我们在之前的文章中也有详细的介绍。
 
@@ -1771,7 +1771,7 @@ if __name__ == "__main__":
         train_epoch(epoch)
 ```
 
-### 5.3.4 SFT 训练
+### 5.3.5 SFT 训练
 
 SFT 训练和预训练的代码基本一样，只是导入的 Dataset 不一样。在这里我们使用的是 SFTDataset，用于多轮对话的训练。
 
@@ -2007,7 +2007,7 @@ if __name__ == "__main__":
 ```
 
 
-### 5.3.4 使用模型生成文本
+### 5.3.6 使用模型生成文本
 
 在模型训练完成后，会在`output`目录下生成模型文件，这个文件就是我们训练好的模型。我们可以使用以下命令生成文本。
 


### PR DESCRIPTION
1. 更改**5.2.1** Word-based Tokenizer 的标号错误。
2. 更新 **5.3** 子段落的标号错误，基于如果我没有错误理解的话。