### PR TITLE
Fix: 修正BERT位置编码机制的描述错误

### DIFF
--- a/docs/chapter3/第三章 预训练语言模型.md
+++ b/docs/chapter3/第三章 预训练语言模型.md
@@ -78,7 +78,7 @@ BERT 的 注意力机制和 Transformer 中 Encoder 的 自注意力机制几乎
   <p>图3.6 BERT 注意力机制结构</p>
 </div>
 
-如图，BERT 的注意力计算过程和 Transformer 的唯一差异在于，在完成注意力分数的计算之后，先通过 Position Embedding 层来融入相对位置信息。这里的 Position Embedding 层，其实就是一层线性矩阵。通过可训练的参数来拟合相对位置，相对而言比 Transformer 使用的绝对位置编码 Sinusoidal 能够拟合更丰富的相对位置信息，但是，这样也增加了不少模型参数，同时完全无法处理超过模型训练长度的输入（例如，对 BERT 而言能处理的最大上下文长度是 512 个 token）。
+BERT的注意力计算过程与Transformer的唯一差异在于其位置编码机制：BERT在输入层将可训练的绝对位置嵌入（而非Transformer使用的Sinusoidal函数）与词嵌入相加，形成融合位置信息的输入表示；而注意力机制的计算过程（包括QKV矩阵生成、注意力分数计算、Softmax）则完全基于该输入表示，未在注意力分数计算后额外添加位置信息。这种设计使BERT能够通过预训练学习最优的位置表示，但也导致其最大上下文长度固定为512token，且相对位置信息需通过模型隐式学习。
 
 可以看出，BERT 的模型架构既是建立在 Transformer 的 Encoder 之上的，这也是为什么说 BERT 沿承了 Transformer 的思想。
 


### PR DESCRIPTION
修改修复了文档中关于 BERT 位置编码机制的错误描述，主要变更点如下：

澄清核心设计：
明确BERT在输入层通过 "词嵌入+可训练绝对位置嵌入" 融合位置信息，而非在注意力分数计算后处理位置编码
强调BERT的注意力机制与Transformer完全一致，未做特殊修改
修正技术细节：
删除 "注意力计算后通过Position Embedding层融入相对位置信息" 的错误表述
补充正确公式：输入表示=Token Embedding+Position Embedding+Segment Embedding
说明相对位置信息需通过模型隐式学习，非显式建模
优化表述准确性：
将原描述中混淆的 "相对位置编码" 相关内容移至后续改进模型（如Transformer-XL/DeBERTa）的介绍部分
明确BERT位置编码的局限性（最大长度512、长距离依赖建模弱）

The revision fixes the incorrect description of BERT's positional encoding mechanism in the document. Key changes include clarifying the core design: explicitly stating that BERT fuses positional information through "Token Embedding + trainable absolute Position Embedding" at the input layer, rather than processing positional encoding after attention score calculation, and emphasizing that BERT's attention mechanism is identical to Transformer with no special modifications. Technical details are corrected by removing the incorrect statement that "relative positional information is integrated through a Position Embedding layer after attention calculation," adding the correct formula "Input representation = Token Embedding + Position Embedding + Segment Embedding," and explaining that relative positional information is implicitly learned by the model rather than explicitly modeled. To enhance expression accuracy, the confusing content related to "relative positional encoding" in the original description is moved to the introduction section of subsequent improved models (e.g., Transformer-XL/DeBERTa), and the limitations of BERT's positional encoding (maximum length of 512, weak modeling of long-distance dependencies) are clarified.