### PR TITLE
修复描述 Decoder Layer 描述不准确的部分

### DIFF
--- a/docs/chapter2/第二章 Transformer架构.md
+++ b/docs/chapter2/第二章 Transformer架构.md
@@ -512,7 +512,7 @@ class Encoder(nn.Module):
 
 ### 2.2.6 Decoder
 
-类似的，我们也可以先搭建 Decoder Layer，再将 N 个 Decoder Layer 组装为 Decoder。但是和 Encoder 不同的是，Decoder 由两个注意力层和一个前馈神经网络组成。第一个注意力层是一个掩码自注意力层，即使用 Mask 的注意力计算，保证每一个 token 只能使用该 token 之前的注意力分数；第二个注意力层是一个多头注意力层，该层将使用第一个注意力层的输出作为 query，使用 Encoder 的输出作为 key 和 value，来计算注意力分数。最后，再经过前馈神经网络：
+类似的，我们也可以先搭建 Decoder Layer，再将 N 个 Decoder Layer 组装为 Decoder。但是和 Encoder Layer 不同的是，Decoder Layer 由两个注意力层和一个前馈神经网络组成。第一个注意力层是一个掩码自注意力层，即使用 Mask 的注意力计算，保证每一个 token 只能使用该 token 之前的注意力分数；第二个注意力层是一个多头注意力层，该层将使用第一个注意力层的输出作为 query，使用 Encoder 的输出作为 key 和 value，来计算注意力分数。最后，再经过前馈神经网络：
 
 ```python
 class DecoderLayer(nn.Module):


### PR DESCRIPTION
从上下文推断，原文 “但是和 Encoder 不同的是，Decoder 由两个注意力层和一个前馈神经网络组成” 改为 “但是和 Encoder Layer 不同的是，Decoder Layer 由两个注意力层和一个前馈神经网络组成” 更准确一些。