### PR TITLE
Update 第二章 Transformer架构.md

### DIFF
--- a/docs/chapter2/第二章 Transformer架构.md
+++ b/docs/chapter2/第二章 Transformer架构.md
@@ -6,7 +6,7 @@
 
 随着 NLP 从统计机器学习向深度学习迈进，作为 NLP 核心问题的文本表示方法也逐渐从统计学习向深度学习迈进。正如我们在第一章所介绍的，文本表示从最初的通过统计学习模型进行计算的向量空间模型、语言模型，通过 Word2Vec 的单层神经网络进入到通过神经网络学习文本表示的时代。但是，从 计算机视觉（Computer Vision，CV）为起源发展起来的神经网络，其核心架构有三种：
 
-- 全连接神经网络（Feedforward Neural Network，FNN），即每一层的神经元都和上下两层的每一个神经元完全连接，如图2.1所示:
+- 全连接神经网络（Fully Connected Neural Network, FCNN），即每一层的神经元都和上下两层的每一个神经元完全连接，如图2.1所示:
 
 <div align="center">
   <img src="https://raw.githubusercontent.com/datawhalechina/happy-llm/main/docs/images/2-figures/1-0.png" alt="图片描述" width="90%"/>


### PR DESCRIPTION
修改chapter2中英文的错误描述。全连接神经网络（Fully Connected Neural Network, FCNN）与前馈神经网络（Feedforward Neural Network, FNN） 并不是完全等同的概念。正确表述应为“全连接神经网络(Fully Connected Neural Network, FCNN),即每一层的神经元都和上下两层的每一个神经元完全连接”。