### PR TITLE
修复Agent在处理信息格式时的错误

### DIFF
--- a/docs/chapter7/Agent/src/core.py
+++ b/docs/chapter7/Agent/src/core.py
@@ -51,7 +51,24 @@ class Agent:
             stream=False,
         )
         if response.choices[0].message.tool_calls:
-            self.messages.append({"role": "assistant", "content": response.choices[0].message.content})
+            # 将包含 tool_calls 的完整 assistant 消息添加到历史中
+            assistant_message = {
+                "role": "assistant",
+                "content": response.choices[0].message.content,
+                "tool_calls": [
+                    {
+                        "id": tool_call.id,
+                        "type": "function",
+                        "function": {
+                            "name": tool_call.function.name,
+                            "arguments": tool_call.function.arguments
+                        }
+                    }
+                    for tool_call in response.choices[0].message.tool_calls
+                ]
+            }
+            self.messages.append(assistant_message)
+
             # 处理工具调用
             tool_list = []
             for tool_call in response.choices[0].message.tool_calls:


### PR DESCRIPTION
问题描述
Agent 在调用工具时出现 BadRequestError: Messages with role 'tool' must be a response to a preceding message with 'tool_calls' 错误,导致无法正常使用工具功能。
根本原因
在 core.py 的 get_completion 方法中,当模型返回 tool_calls 时,代码只将 assistant 消息的 content 添加到消息历史中,而没有包含 tool_calls 字段。这违反了 OpenAI API 规范:当 assistant 调用工具时,该消息必须包含完整的 tool_calls 信息。
解决方案
修改 docs/chapter7/Agent/src/core.py 第 54-70 行,将包含 tool_calls 的完整 assistant 消息添加到消息历史中,确保消息格式符合 API 规范:
assistant (带 tool_calls) → tool (工具返回) → assistant (最终回复)
其他改动
在 .gitignore 中添加了编辑器配置目录 .claude/、.github/、.vscode/ 的忽略规则,避免本地开发环境配置被提交到版本库。
测试
修复后,Agent 可以正常响应需要调用工具的问题(如"今天是几号?"),成功调用 get_current_datetime 等工具并返回结果。