### PR TITLE
新增dropout层描述，防止初学者歧义

### DIFF
--- a/docs/chapter2/第二章 Transformer架构.md
+++ b/docs/chapter2/第二章 Transformer架构.md
@@ -374,7 +374,7 @@ class MLP(nn.Module):
     
 ```
 
-注意，Transformer 的前馈神经网络是由两个线性层中间加一个 RELU 激活函数组成的，以及前馈神经网络还加入了一个 Dropout 层来防止过拟合。
+注意，Transformer 的前馈神经网络是由两个线性层中间加一个 RELU 激活函数组成的，以及前馈神经网络还加入了一个 Dropout 层来防止过拟合。Dropout 层只在训练时开启，推理/测试阶段关闭，所以许多Transformer结构示意图中不会画出该层。
 
 ### 2.2.3 层归一化
 


### PR DESCRIPTION
全文的代码都有dropout层，但是没有阐述，结构示意图也没有。因为dropout层只在训练时防止过拟合才加入，原本的transformer结构中并没有。对于初学者需要解释下。