### PR TITLE
fix(chapter5): 修复 labels/attention_mask 语义并补齐 padding-aware 批量推理

### DIFF
--- a/docs/chapter5/code/dataset.py
+++ b/docs/chapter5/code/dataset.py
@@ -13,7 +13,7 @@ class PretrainDataset(Dataset):
         self.data_path = data_path
         self.tokenizer = tokenizer
         self.max_length = max_length
-        self.padding = 0
+        self.padding = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else 0
         # 预计算每行的起始字节偏移量
         self._offsets = []
         with open(data_path, 'rb') as f:
@@ -51,7 +51,7 @@ class SFTDataset(Dataset):
         self.data_path = data_path
         self.tokenizer = tokenizer
         self.max_length = max_length
-        self.padding = 0
+        self.padding = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else 0
         self._offsets = []
         with open(data_path, 'rb') as f:
             self._offsets.append(0)

--- a/docs/chapter5/code/ddp_pretrain.py
+++ b/docs/chapter5/code/ddp_pretrain.py
@@ -196,6 +196,8 @@ def init_model():
 
     # 从本地路径加载预训练的分词器
     tokenizer = AutoTokenizer.from_pretrained('./tokenizer_k/')
+    if tokenizer.pad_token_id is not None:
+        lm_config.pad_token_id = tokenizer.pad_token_id
 
     # 根据配置创建Transformer模型
     model = Transformer(lm_config)

--- a/docs/chapter5/code/ddp_sft_full.py
+++ b/docs/chapter5/code/ddp_sft_full.py
@@ -127,6 +127,8 @@ def init_model():
 
     # 加载分词器
     tokenizer = AutoTokenizer.from_pretrained('./tokenizer_k/')
+    if tokenizer.pad_token_id is not None:
+        lm_config.pad_token_id = tokenizer.pad_token_id
 
     # 初始化模型
     model = Transformer(lm_config)

--- a/docs/chapter5/code/export_model.py
+++ b/docs/chapter5/code/export_model.py
@@ -15,6 +15,15 @@ def export_model(tokenizer_path, model_config, model_ckpt_path, save_directory):
     ModelConfig.register_for_auto_class()
     Transformer.register_for_auto_class("AutoModelForCausalLM")
 
+    # 加载tokenizer
+    tokenizer = AutoTokenizer.from_pretrained(
+        tokenizer_path,
+        trust_remote_code=True,
+        use_fast=False
+    )
+    if tokenizer.pad_token_id is not None:
+        model_config.pad_token_id = tokenizer.pad_token_id
+
     # 初始化模型
     model = Transformer(model_config)
     device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
@@ -30,13 +39,6 @@ def export_model(tokenizer_path, model_config, model_ckpt_path, save_directory):
     # 加载权重到模型
     model.load_state_dict(state_dict, strict=False)
     print(f'模型参数: {count_parameters(model)/1e6:.2f}M = {count_parameters(model)/1e9:.2f}B')
-
-    # 加载tokenizer
-    tokenizer = AutoTokenizer.from_pretrained(
-        tokenizer_path,
-        trust_remote_code=True,
-        use_fast=False
-    )
 
     # 保存完整模型和tokenizer
     model.save_pretrained(save_directory, safe_serialization=False)

--- a/docs/chapter5/第五章 动手搭建大模型.md
+++ b/docs/chapter5/第五章 动手搭建大模型.md
@@ -568,8 +568,8 @@ class Transformer(PreTrainedModel):
 
         if 'input_ids' in kwargs:
             tokens = kwargs['input_ids']
-        if 'attention_mask' in kwargs:
-            targets = kwargs['attention_mask']
+        if 'labels' in kwargs:
+            targets = kwargs['labels']
 
         # 前向传播函数
         _bsz, seqlen = tokens.shape
@@ -1306,7 +1306,7 @@ class PretrainDataset(Dataset):
         self.data_path = data_path
         self.tokenizer = tokenizer
         self.max_length = max_length
-        self.padding = 0
+        self.padding = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else 0
         # 预计算每行的起始字节偏移量
         self._offsets = []
         with open(data_path, 'rb') as f:
@@ -1365,7 +1365,7 @@ class SFTDataset(Dataset):
         self.data_path = data_path
         self.tokenizer = tokenizer
         self.max_length = max_length
-        self.padding = 0
+        self.padding = tokenizer.pad_token_id if tokenizer.pad_token_id is not None else 0
         self._offsets = []
         with open(data_path, 'rb') as f:
             self._offsets.append(0)


### PR DESCRIPTION
## PR Description

### BG
当前 `chapter5` 示例代码中存在 4 个一致性问题：
1. `forward` 中将 `attention_mask` 误赋值给 `targets`。
2. 训练阶段主要依赖 `loss_mask`，模型注意力层未使用 `padding_mask`。
3. 推理阶段固定取 `-1` 位置 logits，batch 场景下含 padding 会取到错误位置。
4. 数据集 padding 值与 tokenizer `pad_token_id` 不一致（实现写死为0）。

### 本次改动
1. 修复 `forward` 函数，使用 `labels` 作为监督信号（不再把 `attention_mask` 当 targets）。

2. 增加 attention 对 `padding_mask` 的支持
- `Attention.forward` 新增 `attention_mask` 参数。
- Flash Attention 路径构造 `causal + key padding` 组合 mask。
- 非 Flash 路径对 key 位置做 `masked_fill(-inf)`。

3. 修复 batch 推理时最后 token 位置选择
- 在有 `attention_mask` 时按“最后有效 token”取 logits，不再固定 `[:, -1, :]`。
- `generate` / `generate_super` 新增 `attention_mask` 和 `pad_token_id` 参数。
- 支持 batch 内样本提前结束（`stop_id`）后的生成。

4. 对齐 padding 与 tokenizer 配置
- `dataset.py` 改为使用 `tokenizer.pad_token_id`（fallback 为 0）。
- 训练脚本/导出脚本/采样脚本初始化模型时同步 `lm_config.pad_token_id`。

5. 文档中的对应代码片段同步更新

### 影响范围
- `docs/chapter5/code/k_model.py`
- `docs/chapter5/code/dataset.py`
- `docs/chapter5/code/ddp_pretrain.py`
- `docs/chapter5/code/ddp_sft_full.py`
- `docs/chapter5/code/model_sample.py`
- `docs/chapter5/code/export_model.py`
- `docs/chapter5/第五章 动手搭建大模型.md`

### 兼容性
- 对已有 `model(X, Y)` 训练调用兼容。
- 新增参数均为可选，不影响原有单样本推理调用。
- 行为上更贴近标准 CausalLM 的 `labels + attention_mask` 语义。
