### PR TITLE
Fix several typos, add notes, simplify the code, align format and naming to be consistent across the tutorial and python 3.0 and LLAMA

### DIFF
--- a/docs/chapter2/第二章 Transformer架构.md
+++ b/docs/chapter2/第二章 Transformer架构.md
@@ -812,7 +812,7 @@ class Transformer(nn.Module):
             'wpe': PositionalEncoding(args),
             'drop': nn.Dropout(args.dropout),
             'encoder': Encoder(args),
-            'decoder': Decoder(args),
+            'decoder': Decoder(args)
         })
         # 最后的线性层，输入是 dim，输出是词表大小
         self.lm_head = nn.Linear(args.dim, args.vocab_size, bias=False)


### PR DESCRIPTION
Changes 
- (1) Align naming with LLAMA style instead of being a mixture of LLAMA style and GPT-2 style. For example, n_embd is changed to dim, features is changed to dim 
- (2) Fix typos. For example, n_layer is changed to n_layers, and fnn_form is changed to ffn_norm
- (3) Add notes to enable better understandings. For example, a_2, b_2 are noted as weight and bias respectively, 
- (4) Align class initialization with Python 3.0, instead of a mixture of Python 2.0 and Python 3.0. For example, Encoder and Decoder initialization is changed from super(Class, self).__init__() to super().__init__(), 
- (5) change names of parameters to be self explainable. For example, attention_norm_1 and attention_norm_2 are changed to self_attention_norm and cross_attention_norm. 
- (6) simplify the code to make it easy to follow. For example, MultiHeadAttention self.wq/wk/wv/wo initialization parameters are confusing