### PR TITLE
添加断言检查 避免残差连接处报错

### DIFF
--- a/docs/chapter2/第二章 Transformer架构.md
+++ b/docs/chapter2/第二章 Transformer架构.md
@@ -253,6 +253,8 @@ class MultiHeadAttention(nn.Module):
         super().__init__()
         # 隐藏层维度必须是头数的整数倍，因为后面我们会将输入拆成头数个矩阵
         assert args.dim % args.n_heads == 0
+        # n_embd（GPT style) 需要和 dim (LLaMA style) 一致，都指的是隐藏层的维度
+        assert args.n_embd == args.dim, "n_embd 必须等于 dim"
         # 每个头的维度，等于模型维度除以头的总数。
         self.head_dim = args.dim // args.n_heads
         self.n_heads = args.n_heads


### PR DESCRIPTION
添加断言检查 避免残差连接处报错

函数中出现了 n_embd（GPT style) 和 dim (LLaMA style)， 两个参数都指的是隐藏层的维度。 

这样做的好处有两个 (1) 代码易读，避免教程误解, (2) 如果不一致的话，在残差连接处 x + attention_output 会因为不匹配而报错。