### PR TITLE
Add: autocast传递默认参数,防止强制使用FP16,其它类型训练失效

### DIFF
--- a/docs/chapter5/code/ddp_sft_full.py
+++ b/docs/chapter5/code/ddp_sft_full.py
@@ -202,8 +202,11 @@ if __name__ == "__main__":
     torch.manual_seed(42)
     device_type = "cuda" if "cuda" in args.device else "cpu"
 
+    # 在生成 ctx 之前，先将字符串转为 torch 的 dtype 对象
+    ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torch.float16}[args.dtype]
+    
     # 上下文管理器
-    ctx = nullcontext() if device_type == "cpu" else torch.cuda.amp.autocast()
+    ctx = nullcontext() if device_type == "cpu" else torch.cuda.amp.autocast(dtype=ptdtype)
 
     # 初始化模型和分词器
     model, tokenizer = init_model()


### PR DESCRIPTION
如果 autocast() 不传 dtype 参数，它默认且强制使用的是 torch.float16 (FP16). 无论在启动终端时 --dtype bfloat16，这行代码都会把你的设置无效。它在底层依然按照极易溢出（最大值只能到 65504）的 FP16 来跑。一旦模型前期梯度波动稍微大一点，直接溢出，Loss 变成 NaN。