### PR TITLE
docs: fix positional encoding index range

### DIFF
--- a/docs/chapter2/第二章 Transformer架构.md
+++ b/docs/chapter2/第二章 Transformer架构.md
@@ -733,13 +733,13 @@ $$
 当 $H$ 不是一个单位矩阵时，因为模型的 Embedding 层所形成的 d 维向量之间任意两个维度的相关性比较小，满足一定的解耦性，我们可以将其视作对角矩阵，那么使用上述编码：
 
 $$
-\begin{equation}\boldsymbol{p}_m^{\top} \boldsymbol{\mathcal{H}} \boldsymbol{p}_n=\sum_{i=1}^{d/2} \boldsymbol{\mathcal{H}}_{2i,2i} \cos m\theta_i \cos n\theta_i + \boldsymbol{\mathcal{H}}_{2i+1,2i+1} \sin m\theta_i \sin n\theta_i\end{equation}
+\begin{equation}\boldsymbol{p}_m^{\top} \boldsymbol{\mathcal{H}} \boldsymbol{p}_n=\sum_{i=0}^{d/2-1} \boldsymbol{\mathcal{H}}_{2i,2i} \cos m\theta_i \cos n\theta_i + \boldsymbol{\mathcal{H}}_{2i+1,2i+1} \sin m\theta_i \sin n\theta_i\end{equation}
 $$
 
 通过积化和差：
 
 $$
-\begin{equation}\sum_{i=1}^{d/2} \frac{1}{2}\left(\boldsymbol{\mathcal{H}}_{2i,2i} + \boldsymbol{\mathcal{H}}_{2i+1,2i+1}\right) \cos (m-n)\theta_i + \frac{1}{2}\left(\boldsymbol{\mathcal{H}}_{2i,2i} - \boldsymbol{\mathcal{H}}_{2i+1,2i+1}\right) \cos (m+n)\theta_i \end{equation}
+\begin{equation}\sum_{i=0}^{d/2-1} \frac{1}{2}\left(\boldsymbol{\mathcal{H}}_{2i,2i} + \boldsymbol{\mathcal{H}}_{2i+1,2i+1}\right) \cos (m-n)\theta_i + \frac{1}{2}\left(\boldsymbol{\mathcal{H}}_{2i,2i} - \boldsymbol{\mathcal{H}}_{2i+1,2i+1}\right) \cos (m+n)\theta_i \end{equation}
 $$
 
 说明该编码仍然可以表示相对位置。


### PR DESCRIPTION
## Summary

- Correct the summation index range in the positional encoding derivation from `i = 1, ..., d/2` to `i = 0, ..., d/2 - 1`.
- Apply the same correction to the following product-to-sum equation for consistency.

## Why

The positional encoding vector uses `??` through `?_{d/2-1}`. Starting the summation at 1 omits dimensions 0 and 1, while the final term addresses indices outside a `d`-dimensional vector.

## Impact

This is a documentation-only correction. Runtime code and model behavior are unchanged.

## Validation

- Ran `git diff --check`.
- Verified the old summation range no longer appears in the section.
- Verified both corrected equations use `i = 0, ..., d/2 - 1`.
- Verified Markdown code fences remain balanced.

Fixes #203