### PR TITLE
fix: 修复章节 2.1.6/2.2.5/2.2.6 维度不一致——wo 输出与 MLP 输入 dim → n_embd

### DIFF
--- a/docs/chapter2/code/transformer.py
+++ b/docs/chapter2/code/transformer.py
@@ -36,8 +36,8 @@ class MultiHeadAttention(nn.Module):
         self.wq = nn.Linear(args.n_embd, self.n_heads * self.head_dim, bias=False)
         self.wk = nn.Linear(args.n_embd, self.n_heads * self.head_dim, bias=False)
         self.wv = nn.Linear(args.n_embd, self.n_heads * self.head_dim, bias=False)
-        # 输出权重矩阵，维度为 dim x dim（head_dim = dim / n_heads）
-        self.wo = nn.Linear(self.n_heads * self.head_dim, args.dim, bias=False)
+        # 输出权重矩阵，输出与残差流相连，维度需与 n_embd 一致（head_dim = dim / n_heads）
+        self.wo = nn.Linear(self.n_heads * self.head_dim, args.n_embd, bias=False)
         # 注意力的 dropout
         self.attn_dropout = nn.Dropout(args.dropout)
         # 残差连接的 dropout
@@ -139,7 +139,7 @@ class EncoderLayer(nn.Module):
         # Encoder 不需要掩码，传入 is_causal=False
         self.attention = MultiHeadAttention(args, is_causal=False)
         self.fnn_norm = LayerNorm(args.n_embd)
-        self.feed_forward = MLP(args.dim, args.dim, args.dropout)
+        self.feed_forward = MLP(args.n_embd, args.dim, args.dropout)
 
     def forward(self, x):
         # Layer Norm
@@ -177,7 +177,7 @@ class DecoderLayer(nn.Module):
         self.attention = MultiHeadAttention(args, is_causal=False)
         self.ffn_norm = LayerNorm(args.n_embd)
         # 第三个部分是 MLP
-        self.feed_forward = MLP(args.dim, args.dim, args.dropout)
+        self.feed_forward = MLP(args.n_embd, args.dim, args.dropout)
 
     def forward(self, x, enc_out):
         # Layer Norm

--- a/docs/chapter2/第二章 Transformer架构.md
+++ b/docs/chapter2/第二章 Transformer架构.md
@@ -263,8 +263,8 @@ class MultiHeadAttention(nn.Module):
         self.wq = nn.Linear(args.n_embd, self.n_heads * self.head_dim, bias=False)
         self.wk = nn.Linear(args.n_embd, self.n_heads * self.head_dim, bias=False)
         self.wv = nn.Linear(args.n_embd, self.n_heads * self.head_dim, bias=False)
-        # 输出权重矩阵，维度为 dim x dim（head_dim = dim / n_heads）
-        self.wo = nn.Linear(self.n_heads * self.head_dim, args.dim, bias=False)
+        # 输出权重矩阵，输出与残差流相连，维度需与 n_embd 一致（head_dim = dim / n_heads）
+        self.wo = nn.Linear(self.n_heads * self.head_dim, args.n_embd, bias=False)
         # 注意力的 dropout
         self.attn_dropout = nn.Dropout(args.dropout)
         # 残差连接的 dropout
@@ -474,7 +474,7 @@ class EncoderLayer(nn.Module):
         # Encoder 不需要掩码，传入 is_causal=False
         self.attention = MultiHeadAttention(args, is_causal=False)
         self.fnn_norm = LayerNorm(args.n_embd)
-        self.feed_forward = MLP(args.dim, args.dim, args.dropout)
+        self.feed_forward = MLP(args.n_embd, args.dim, args.dropout)
 
     def forward(self, x):
         # Layer Norm
@@ -524,7 +524,7 @@ class DecoderLayer(nn.Module):
         self.attention = MultiHeadAttention(args, is_causal=False)
         self.ffn_norm = LayerNorm(args.n_embd)
         # 第三个部分是 MLP
-        self.feed_forward = MLP(args.dim, args.dim, args.dropout)
+        self.feed_forward = MLP(args.n_embd, args.dim, args.dropout)
 
     def forward(self, x, enc_out):
         # Layer Norm


### PR DESCRIPTION
fix: 修复章节 2.1.6/2.2.5/2.2.6 维度不一致——wo 输出与 MLP 输入 dim → n_embd

## 问题

#199 反馈：当 `n_embd != dim` 时 Encoder/Decoder 无法前向传播，报错
`RuntimeError: The size of tensor a (256) must match the size of tensor b (512)`。

## 根因

第二章教学代码中，`wq/wk/wv` 的输入维度与各 `LayerNorm` 均使用 `args.n_embd`，
但两处维度未与残差流对齐：

1. **2.1.6 多头注意力**：`self.wo = nn.Linear(n_heads*head_dim, args.dim)` ——
   输出投影维度用了 `args.dim`，残差相加 `x + attn_out` 时 `n_embd` 与 `dim` 不匹配
2. **2.2.5 EncoderLayer / 2.2.6 DecoderLayer**：`MLP(args.dim, args.dim, ...)` ——
   MLP 输出维度为 `args.dim`，`h + feed_forward(...)` 同样无法相加

## 修复

- `wo` 输出维度：`args.dim` → `args.n_embd`（md 2.1.6 + transformer.py 各 1 处）
- `MLP` 首参：`args.dim` → `args.n_embd`（md 2.2.5/2.2.6 + transformer.py 各 2 处）
- 同步更新对应注释

修复后 `n_embd != dim`（如 `n_embd=256, dim=512`）可正常前向，残差流维度全程
`n_embd` 自洽。已用 #199 中复现代码验证通过。

Closes #199