### PR TITLE
fix(chapter5): 修正 AMP dtype 与 BF16 梯度缩放

### DIFF
--- a/docs/chapter5/code/amp_utils.py
+++ b/docs/chapter5/code/amp_utils.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from contextlib import nullcontext
+
+import torch
+
+
+TORCH_DTYPES = {
+    "float32": torch.float32,
+    "bfloat16": torch.bfloat16,
+    "float16": torch.float16,
+}
+
+
+def configure_amp(device_type, dtype):
+    """根据设备和精度配置 autocast 上下文与梯度缩放器。"""
+    if dtype not in TORCH_DTYPES:
+        supported = ", ".join(TORCH_DTYPES)
+        raise ValueError(f"不支持的数据类型 {dtype!r}，可选值为：{supported}")
+
+    if device_type == "cuda" and dtype != "float32":
+        ctx = torch.amp.autocast(device_type="cuda", dtype=TORCH_DTYPES[dtype])
+    else:
+        ctx = nullcontext()
+
+    # BF16 与 FP32 具有相同的指数位宽，通常不需要梯度缩放。
+    scaler = torch.amp.GradScaler(
+        "cuda",
+        enabled=(device_type == "cuda" and dtype == "float16"),
+    )
+    return ctx, scaler

--- a/docs/chapter5/code/ddp_pretrain.py
+++ b/docs/chapter5/code/ddp_pretrain.py
@@ -9,10 +9,10 @@ import pandas as pd
 import torch
 from torch import optim
 from torch.utils.data import DataLoader
-from contextlib import nullcontext
 
 from transformers import AutoTokenizer
 
+from amp_utils import configure_amp
 from k_model import ModelConfig, Transformer
 from dataset import PretrainDataset
 
@@ -287,9 +287,8 @@ if __name__ == "__main__":
     # 确定设备类型（用于选择合适的上下文管理器）
     device_type = "cuda" if "cuda" in args.device else "cpu"
 
-    # 设置混合精度训练的上下文管理器
-    # CPU训练时使用nullcontext，GPU训练时使用autocast
-    ctx = nullcontext() if device_type == "cpu" else torch.cuda.amp.autocast()
+    # 按参数显式选择混合精度类型；仅FP16启用梯度缩放
+    ctx, scaler = configure_amp(device_type, args.dtype)
 
     # ==================== 模型和数据初始化 ====================
     # 初始化模型和分词器
@@ -309,10 +308,6 @@ if __name__ == "__main__":
     )
 
     # ==================== 优化器和训练组件初始化 ====================
-    # 初始化混合精度训练的梯度缩放器
-    # 只有在使用float16或bfloat16时才启用
-    scaler = torch.cuda.amp.GradScaler(enabled=(args.dtype in ['float16', 'bfloat16']))
-    
     # 初始化Adam优化器
     optimizer = optim.Adam(model.parameters(), lr=args.learning_rate)
 

--- a/docs/chapter5/code/ddp_sft_full.py
+++ b/docs/chapter5/code/ddp_sft_full.py
@@ -8,10 +8,10 @@ import pandas as pd
 import torch
 from torch import optim
 from torch.utils.data import DataLoader
-from contextlib import nullcontext
 
 from transformers import AutoTokenizer
 
+from amp_utils import configure_amp
 from k_model import ModelConfig, Transformer
 from dataset import SFTDataset
 
@@ -202,11 +202,8 @@ if __name__ == "__main__":
     torch.manual_seed(42)
     device_type = "cuda" if "cuda" in args.device else "cpu"
 
-    # 在生成 ctx 之前，先将字符串转为 torch 的 dtype 对象
-    ptdtype = {'float32': torch.float32, 'bfloat16': torch.bfloat16, 'float16': torch.float16}[args.dtype]
-    
-    # 上下文管理器
-    ctx = nullcontext() if device_type == "cpu" else torch.cuda.amp.autocast(dtype=ptdtype)
+    # 按参数显式选择混合精度类型；仅FP16启用梯度缩放
+    ctx, scaler = configure_amp(device_type, args.dtype)
 
     # 初始化模型和分词器
     model, tokenizer = init_model()
@@ -222,8 +219,7 @@ if __name__ == "__main__":
         num_workers=args.num_workers
     )
 
-    # 缩放器和优化器
-    scaler = torch.cuda.amp.GradScaler(enabled=(args.dtype in ['float16', 'bfloat16']))
+    # 优化器
     optimizer = optim.AdamW(model.parameters(), lr=args.learning_rate)
 
     # 开始训练

--- a/docs/chapter5/code/tests/test_amp_utils.py
+++ b/docs/chapter5/code/tests/test_amp_utils.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+import pathlib
+import sys
+import unittest
+from contextlib import nullcontext
+from unittest.mock import patch
+
+import torch
+
+
+CODE_DIR = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(CODE_DIR))
+
+from amp_utils import configure_amp
+
+
+class ConfigureAmpTest(unittest.TestCase):
+    def test_cpu_disables_autocast_and_scaler_for_every_dtype(self):
+        for dtype in ("float32", "bfloat16", "float16"):
+            with self.subTest(dtype=dtype), patch(
+                "amp_utils.torch.amp.autocast"
+            ) as autocast, patch(
+                "amp_utils.torch.amp.GradScaler"
+            ) as grad_scaler:
+                ctx, _ = configure_amp("cpu", dtype)
+
+                self.assertIsInstance(ctx, nullcontext)
+                autocast.assert_not_called()
+                grad_scaler.assert_called_once_with("cuda", enabled=False)
+
+    def test_cuda_uses_requested_low_precision_dtype(self):
+        cases = (
+            ("bfloat16", torch.bfloat16, False),
+            ("float16", torch.float16, True),
+        )
+        for dtype, torch_dtype, scaler_enabled in cases:
+            with self.subTest(dtype=dtype), patch(
+                "amp_utils.torch.amp.autocast"
+            ) as autocast, patch(
+                "amp_utils.torch.amp.GradScaler"
+            ) as grad_scaler:
+                configure_amp("cuda", dtype)
+
+                autocast.assert_called_once_with(
+                    device_type="cuda",
+                    dtype=torch_dtype,
+                )
+                grad_scaler.assert_called_once_with(
+                    "cuda",
+                    enabled=scaler_enabled,
+                )
+
+    def test_cuda_float32_disables_autocast_and_scaler(self):
+        with patch("amp_utils.torch.amp.autocast") as autocast, patch(
+            "amp_utils.torch.amp.GradScaler"
+        ) as grad_scaler:
+            ctx, _ = configure_amp("cuda", "float32")
+
+            self.assertIsInstance(ctx, nullcontext)
+            autocast.assert_not_called()
+            grad_scaler.assert_called_once_with("cuda", enabled=False)
+
+    def test_rejects_unknown_dtype(self):
+        with self.assertRaisesRegex(ValueError, "不支持的数据类型"):
+            configure_amp("cuda", "float64")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/chapter5/第五章 动手搭建大模型.md
+++ b/docs/chapter5/第五章 动手搭建大模型.md
@@ -1498,8 +1498,13 @@ class SFTDataset(Dataset):
 接下来就是最重要的部分，训练模型!
 
 > 注：在使用下面代码进行模型训练时，需要指定 `--data_path` 参数为预处理好的数据集路径，例如 `--data_path seq_monkey_datawhale.jsonl`，也需要指定要用哪几张GPU进行训练，例如 `--gpus 0,1`。
+>
+> `amp_utils.py` 会根据 `--dtype` 显式设置 CUDA autocast：BF16 与 FP16 分别使用对应精度，FP32 不启用 autocast；GradScaler 仅在 FP16 训练时启用。BF16 与 FP32 具有相同的指数位宽，通常不需要通过梯度缩放避免下溢。PyTorch 2.4 的 [AMP 文档](https://docs.pytorch.org/docs/2.4/amp.html)同样将梯度缩放用于 FP16 下溢防护，并在 BF16 示例中仅使用 autocast。
 
 ```python
+from amp_utils import configure_amp
+
+
 def get_lr(it, all):
     """
     计算当前迭代的学习率，使用余弦退火调度策略
@@ -1754,9 +1759,8 @@ if __name__ == "__main__":
     # 确定设备类型（用于选择合适的上下文管理器）
     device_type = "cuda" if "cuda" in args.device else "cpu"
 
-    # 设置混合精度训练的上下文管理器
-    # CPU训练时使用nullcontext，GPU训练时使用autocast
-    ctx = nullcontext() if device_type == "cpu" else torch.cuda.amp.autocast()
+    # 按参数显式选择混合精度类型；仅FP16启用梯度缩放
+    ctx, scaler = configure_amp(device_type, args.dtype)
 
     # ==================== 模型和数据初始化 ====================
     # 初始化模型和分词器
@@ -1776,10 +1780,6 @@ if __name__ == "__main__":
     )
 
     # ==================== 优化器和训练组件初始化 ====================
-    # 初始化混合精度训练的梯度缩放器
-    # 只有在使用float16或bfloat16时才启用
-    scaler = torch.cuda.amp.GradScaler(enabled=(args.dtype in ['float16', 'bfloat16']))
-    
     # 初始化Adam优化器
     optimizer = optim.Adam(model.parameters(), lr=args.learning_rate)
 
@@ -1807,10 +1807,10 @@ import pandas as pd
 import torch
 from torch import optim
 from torch.utils.data import DataLoader
-from contextlib import nullcontext
 
 from transformers import AutoTokenizer
 
+from amp_utils import configure_amp
 from k_model import ModelConfig, Transformer
 from dataset import SFTDataset
 
@@ -1999,8 +1999,8 @@ if __name__ == "__main__":
     torch.manual_seed(42)
     device_type = "cuda" if "cuda" in args.device else "cpu"
 
-    # 上下文管理器
-    ctx = nullcontext() if device_type == "cpu" else torch.cuda.amp.autocast()
+    # 按参数显式选择混合精度类型；仅FP16启用梯度缩放
+    ctx, scaler = configure_amp(device_type, args.dtype)
 
     # 初始化模型和分词器
     model, tokenizer = init_model()
@@ -2016,8 +2016,7 @@ if __name__ == "__main__":
         num_workers=args.num_workers
     )
 
-    # 缩放器和优化器
-    scaler = torch.cuda.amp.GradScaler(enabled=(args.dtype in ['float16', 'bfloat16']))
+    # 优化器
     optimizer = optim.AdamW(model.parameters(), lr=args.learning_rate)
 
     # 开始训练


### PR DESCRIPTION
## 问题

`ddp_pretrain.py` 的 `--dtype` 默认为 `bfloat16`，但 CUDA autocast 没有接收该参数。PyTorch 2.4 中 CUDA autocast 的默认 dtype 是 FP16，因此默认命令实际进入 FP16 autocast；这也解释了 Issue #162 中关闭 GradScaler 后训练异常的现象：关闭的是 FP16 路径的梯度缩放，而不是一个真正的 BF16 路径。

此外，预训练和 SFT 代码都对 BF16 启用了 GradScaler。BF16 与 FP32 具有相同的指数位宽，PyTorch 的 AMP 文档将梯度缩放用于避免 FP16 梯度下溢，BF16 通常不需要该步骤。

Refs #162

## 改动

- 新增 `amp_utils.configure_amp()`，集中定义设备、autocast dtype 和 GradScaler 的组合。
- CUDA BF16/FP16 显式传入对应 `torch.dtype`；CUDA FP32 与 CPU 不启用 autocast。
- 仅在 CUDA FP16 下启用 GradScaler。
- 让预训练与 SFT 共用同一配置，避免两条路径再次漂移。
- 同步第五章代码片段和说明，并引用 PyTorch 2.4 AMP 文档。
- 新增定向测试，覆盖 CPU 和 CUDA 下 FP32/BF16/FP16 组合及非法 dtype。

## 最小复现

当前 `main` 上：

```python
args.dtype = "bfloat16"
ctx = torch.cuda.amp.autocast()
```

PyTorch 2.4 的 CUDA autocast 默认 dtype：

```python
torch.get_autocast_dtype("cuda")  # torch.float16
```

因此 `args.dtype` 没有控制实际 autocast 精度。

## 验证

环境：macOS arm64、Python 3.10.20、仓库锁定依赖 `torch==2.4.0`。

```bash
PYTHONPATH=.deps python3 -m unittest discover \
  -s docs/chapter5/code/tests -v
```

结果：4 个测试全部通过。

```text
Ran 4 tests in 0.002s
OK
```

```bash
python3 -m py_compile \
  docs/chapter5/code/amp_utils.py \
  docs/chapter5/code/ddp_pretrain.py \
  docs/chapter5/code/ddp_sft_full.py \
  docs/chapter5/code/tests/test_amp_utils.py
git diff --check
```

结果：均通过。

另使用固定随机种子执行了一个 CPU 线性层的 forward/backward/optimizer step，结果为：

```text
{'torch': '2.4.0', 'loss_finite': True, 'scaler_enabled': False}
```

## 验证限制

当前环境没有 NVIDIA GPU，因此没有声称完成 CUDA 真实训练或复现 Issue 中的完整 loss 曲线。CUDA 分支通过 mock 验证了传给 PyTorch 2.4 API 的 dtype 与 scaler 开关；建议维护者在合并前使用一张支持 BF16 的 GPU 运行短训练 smoke test。

## 依据

- PyTorch 2.4 AMP 文档：https://docs.pytorch.org/docs/2.4/amp.html
- 已合并 PR #195 已在 `ddp_sft_full.py` 中采用显式 autocast dtype；本 PR 补齐预训练路径，并统一 GradScaler 语义。
