### PR TITLE
fix(chapter5): 修复 SFT 无法学习 im_end

### DIFF
--- a/docs/chapter5/code/dataset.py
+++ b/docs/chapter5/code/dataset.py
@@ -116,4 +116,6 @@ class SFTDataset(Dataset):
         X = np.array(input_id[:-1]).astype(np.int64)
         Y = np.array(input_id[1:]).astype(np.int64)
         loss_mask = np.array(loss_mask[1:]).astype(np.int64)
+        # 使用独立的 ignore_index，避免 pad_token 与 eos_token 共用 id 时忽略结束符
+        Y = np.where(loss_mask == 1, Y, -100).astype(np.int64)
         return torch.from_numpy(X), torch.from_numpy(Y), torch.from_numpy(loss_mask)

--- a/docs/chapter5/code/tests/test_sft_dataset.py
+++ b/docs/chapter5/code/tests/test_sft_dataset.py
@@ -1,0 +1,83 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import torch
+from transformers import AutoTokenizer
+
+from dataset import SFTDataset
+from k_model import ModelConfig, Transformer
+
+
+CODE_DIR = Path(__file__).resolve().parents[1]
+
+
+class SFTDatasetTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tokenizer = AutoTokenizer.from_pretrained(CODE_DIR / "tokenizer_k")
+
+    def setUp(self):
+        self.data_file = tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".jsonl",
+            encoding="utf-8",
+            delete=False,
+        )
+        json.dump(
+            [
+                {"role": "user", "content": "你好"},
+                {"role": "assistant", "content": "你好，有什么可以帮你？"},
+                {"role": "user", "content": "再见"},
+                {"role": "assistant", "content": "再见！"},
+            ],
+            self.data_file,
+            ensure_ascii=False,
+        )
+        self.data_file.write("\n")
+        self.data_file.close()
+
+    def tearDown(self):
+        Path(self.data_file.name).unlink()
+
+    def test_im_end_label_is_not_ignored(self):
+        self.assertEqual(
+            self.tokenizer.pad_token_id,
+            self.tokenizer.eos_token_id,
+        )
+        dataset = SFTDataset(
+            self.data_file.name,
+            self.tokenizer,
+            max_length=64,
+        )
+        inputs, labels, loss_mask = dataset[0]
+
+        active_labels = labels[loss_mask.bool()]
+        self.assertEqual(
+            active_labels.eq(self.tokenizer.eos_token_id).sum().item(),
+            2,
+        )
+        self.assertTrue(torch.all(labels[loss_mask == 0] == -100))
+
+        config = ModelConfig(
+            dim=16,
+            n_layers=1,
+            n_heads=4,
+            n_kv_heads=2,
+            vocab_size=len(self.tokenizer),
+            hidden_dim=32,
+            multiple_of=8,
+            max_seq_len=64,
+            pad_token_id=self.tokenizer.pad_token_id,
+        )
+        model = Transformer(config).eval()
+        losses = model(inputs.unsqueeze(0), labels.unsqueeze(0)).last_loss
+        eos_positions = (labels == self.tokenizer.eos_token_id) & loss_mask.bool()
+
+        self.assertTrue(torch.all(losses[eos_positions] > 0))
+        self.assertTrue(torch.all(losses[labels == -100] == 0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/chapter5/第五章 动手搭建大模型.md
+++ b/docs/chapter5/第五章 动手搭建大模型.md
@@ -37,6 +37,7 @@ class ModelConfig(PretrainedConfig):
             max_seq_len: int = 512, # 最大序列长度
             dropout: float = 0.0, # dropout概率
             flash_attn: bool = True, # 是否使用Flash Attention
+            pad_token_id: int = 0, # 填充 token id
             **kwargs,
     ):
         self.dim = dim
@@ -50,6 +51,7 @@ class ModelConfig(PretrainedConfig):
         self.max_seq_len = max_seq_len
         self.dropout = dropout
         self.flash_attn = flash_attn
+        self.pad_token_id = pad_token_id
         super().__init__(**kwargs)
 ```
 
@@ -594,7 +596,15 @@ class Transformer(PreTrainedModel):
         if targets is not None:
             # 如果给定了目标，计算损失
             logits = self.output(h)
-            self.last_loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=0, reduction='none')
+            ignore_index = self.args.pad_token_id if self.args.pad_token_id is not None else 0
+            if torch.any(targets == -100):
+                ignore_index = -100
+            self.last_loss = F.cross_entropy(
+                logits.view(-1, logits.size(-1)),
+                targets.view(-1),
+                ignore_index=ignore_index,
+                reduction='none'
+            )
         else:
             # 推理时的小优化：只对最后一个位置的输出进行前向传播
             logits = self.output(h[:, [-1], :]) 
@@ -1435,17 +1445,19 @@ class SFTDataset(Dataset):
         X = np.array(input_id[:-1]).astype(np.int64)
         Y = np.array(input_id[1:]).astype(np.int64)
         loss_mask = np.array(loss_mask[1:]).astype(np.int64)
+        # 使用独立的 ignore_index，避免 pad_token 与 eos_token 共用 id 时忽略结束符
+        Y = np.where(loss_mask == 1, Y, -100).astype(np.int64)
         return torch.from_numpy(X), torch.from_numpy(Y), torch.from_numpy(loss_mask)
 ```
 
-在 SFT 阶段，这里使用的是多轮对话数据集，所以就需要区分哪些位置需要计算损失，哪些位置不需要计算损失。在上面的代码中，我使用了一个 `generate_loss_mask` 函数来生成 `loss_mask`。这个函数主要是用来生成 `loss_mask`，其中 `loss_mask` 的生成规则是：当遇到 `|<im_start|>assistant\n` 时，就开始计算损失，直到遇到 `|<im_end|>` 为止。这样就可以保证我们的模型在 SFT 阶段只计算当前轮的对话内容，如图5.4所示。
+在 SFT 阶段，这里使用的是多轮对话数据集，所以就需要区分哪些位置需要计算损失，哪些位置不需要计算损失。在上面的代码中，我使用了一个 `generate_loss_mask` 函数来生成 `loss_mask`。这个函数主要是用来生成 `loss_mask`，其中 `loss_mask` 的生成规则是：当遇到 `<|im_start|>assistant\n` 时，就开始计算损失，直到遇到 `<|im_end|>` 为止。随后将不参与损失计算的标签设为 PyTorch 交叉熵默认使用的 `ignore_index=-100`。由于本项目的 `pad_token` 与 `<|im_end|>` 共用同一个 token id，不能直接把 `pad_token_id` 作为 SFT 的 `ignore_index`，否则模型也会忽略答案结束符。这样可以保证模型只学习助手回复，同时仍能学习何时停止生成，如图5.4所示。
 
 <div align='center'>
     <img src="https://raw.githubusercontent.com/datawhalechina/happy-llm/main/docs/images/5-images/sftdataset.png" alt="alt text" width="90%">
     <p>图5.4 SFT 损失函数计算</p>
 </div>
 
-可以看到，其实 SFT Dataset 和 Pretrain Dataset 的 `X` 和 `Y` 是一样的，只是在 SFT Dataset 中我们需要生成一个 `loss_mask` 来标记哪些位置需要计算损失，哪些位置不需要计算损失。 图中 `Input ids` 中的蓝色小方格就是AI的回答，所以是需要模型学习的地方。所以在 `loss_mask` 中，蓝色小方格对应的位置是黄色，其他位置是灰色。在代码 `loss_mask` 中的 1 对应的位置计算损失，0 对应的位置不计算损失。
+可以看到，SFT Dataset 和 Pretrain Dataset 的 `X` 构造方式相同，但 SFT Dataset 会将非助手回复位置的 `Y` 设为 `-100`，并生成对应的 `loss_mask`。图中 `Input ids` 中的蓝色小方格就是 AI 的回答，所以是需要模型学习的地方。在 `loss_mask` 中，蓝色小方格对应的位置是黄色，其他位置是灰色；代码中 `loss_mask` 为 1 的位置计算损失，为 0 的位置不计算损失。
 
 
 ### 5.3.4 预训练


### PR DESCRIPTION
## 问题

`tokenizer_k` 将 `pad_token` 和 `<|im_end|>` 都映射到 token id `4`。原来的 `SFTDataset` 返回普通 token id 作为全部标签，而 `Transformer.forward()` 在标签中没有 `-100` 时使用 `pad_token_id` 作为 `ignore_index`。因此，虽然 `loss_mask` 包含助手回复末尾的 `<|im_end|>`，交叉熵已经先把该位置的损失置为 0，后续乘掩码无法恢复，模型不会从 SFT 样本学习回答结束符。

最小复现使用仓库内 `tokenizer_k` 和两轮对话样本：修复前两个助手 `<|im_end|>` 都在有效 `loss_mask` 内，但对应交叉熵均为 `0.0`。

Refs #211

## 改动

- 将 SFT 非助手位置的标签设为标准 `ignore_index=-100`，保留助手内容和 `<|im_end|>` 的真实 token 标签。
- 保持预训练数据路径不变；继续返回 `loss_mask`，兼容现有训练循环。
- 同步第五章的数据集、模型损失代码片段与行为说明。
- 新增真实 tokenizer + 微型 `Transformer` 回归测试，覆盖两轮对话、pad/eos 共用 id、结束符非零损失和非助手标签忽略。

未修改 `model_sample.py` 的 `skip_special_tokens`：该参数只改变解码展示，不能修复训练标签。

## 验证

环境：

- Python 3.10.20
- torch 2.4.0
- transformers 4.44.0
- numpy 1.26.4
- pandas 1.5.3

命令：

```bash
PYTHONDONTWRITEBYTECODE=1 \
PYTHONPATH="<deps>:docs/chapter5/code" \
python3 -m unittest discover -s docs/chapter5/code/tests -v

python3 -m py_compile \
  docs/chapter5/code/dataset.py \
  docs/chapter5/code/tests/test_sft_dataset.py

ruff check docs/chapter5/code/tests/test_sft_dataset.py
git diff --check
```

结果：1 个回归测试通过，语法检查、测试文件静态检查与差异检查通过。

## 风险

- 未执行完整数据集或 GPU SFT，当前证据覆盖标签构造和模型损失契约，不代表训练质量或收敛曲线验证。
- 训练循环仍同时使用 `-100` 和 `loss_mask`，两者语义一致但存在冗余；本 PR 保留现有接口以控制改动范围。
- 若样本在截断后不含任何完整助手回复，现有 `loss_mask.sum()` 仍可能为 0；这是既有边界情况，不在本修复范围内。
