### PR TITLE
fix(rag): 按 Token 计算分块重叠

### DIFF
--- a/docs/chapter7/RAG/test_utils.py
+++ b/docs/chapter7/RAG/test_utils.py
@@ -1,0 +1,50 @@
+import unittest
+
+from utils import ReadFiles, enc
+
+
+class GetChunkTest(unittest.TestCase):
+    def test_long_chinese_line_uses_token_overlap(self):
+        max_token_len = 20
+        cover_content = 5
+
+        chunks = ReadFiles.get_chunk(
+            "你好世界" * 30,
+            max_token_len=max_token_len,
+            cover_content=cover_content,
+        )
+
+        self.assertGreater(len(chunks), 1)
+        self.assertTrue(
+            all(len(enc.encode(chunk)) <= max_token_len for chunk in chunks)
+        )
+        for previous, current in zip(chunks, chunks[1:]):
+            expected_overlap = enc.decode(enc.encode(previous)[-cover_content:])
+            self.assertTrue(current.startswith(expected_overlap))
+
+    def test_overlap_does_not_consume_new_content_budget_twice(self):
+        chunks = ReadFiles.get_chunk(
+            "\n".join(["alpha"] * 4),
+            max_token_len=6,
+            cover_content=2,
+        )
+
+        self.assertEqual(2, len(chunks))
+        self.assertTrue(all(len(enc.encode(chunk)) <= 6 for chunk in chunks))
+        self.assertEqual(["alpha", "alpha"], chunks[-1].splitlines()[-2:])
+
+    def test_rejects_invalid_token_budgets(self):
+        invalid_arguments = (
+            {"max_token_len": 0, "cover_content": 0},
+            {"max_token_len": 10, "cover_content": -1},
+            {"max_token_len": 10, "cover_content": 10},
+        )
+
+        for arguments in invalid_arguments:
+            with self.subTest(arguments=arguments):
+                with self.assertRaises(ValueError):
+                    ReadFiles.get_chunk("text", **arguments)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/chapter7/RAG/test_utils.py
+++ b/docs/chapter7/RAG/test_utils.py
@@ -22,6 +22,20 @@ class GetChunkTest(unittest.TestCase):
             expected_overlap = enc.decode(enc.encode(previous)[-cover_content:])
             self.assertTrue(current.startswith(expected_overlap))
 
+    def test_unicode_character_is_not_split_across_token_boundaries(self):
+        text = "😊"
+        self.assertEqual(2, len(enc.encode(text)))
+
+        chunks = ReadFiles.get_chunk(
+            text,
+            max_token_len=2,
+            cover_content=1,
+        )
+
+        self.assertEqual([text], chunks)
+        self.assertNotIn("\ufffd", "".join(chunks))
+        self.assertTrue(all(len(enc.encode(chunk)) <= 2 for chunk in chunks))
+
     def test_overlap_does_not_consume_new_content_budget_twice(self):
         chunks = ReadFiles.get_chunk(
             "\n".join(["alpha"] * 4),

--- a/docs/chapter7/RAG/test_utils.py
+++ b/docs/chapter7/RAG/test_utils.py
@@ -47,6 +47,17 @@ class GetChunkTest(unittest.TestCase):
         self.assertTrue(all(len(enc.encode(chunk)) <= 6 for chunk in chunks))
         self.assertEqual(["alpha", "alpha"], chunks[-1].splitlines()[-2:])
 
+    def test_overlap_is_kept_before_first_part_of_long_line(self):
+        chunks = ReadFiles.get_chunk(
+            "alpha\n" + "你好世界" * 20,
+            max_token_len=10,
+            cover_content=2,
+        )
+
+        self.assertEqual("alpha", chunks[0])
+        self.assertTrue(chunks[1].startswith("alpha\n"))
+        self.assertTrue(all(len(enc.encode(chunk)) <= 10 for chunk in chunks))
+
     def test_rejects_invalid_token_budgets(self):
         invalid_arguments = (
             {"max_token_len": 0, "cover_content": 0},

--- a/docs/chapter7/RAG/utils.py
+++ b/docs/chapter7/RAG/utils.py
@@ -130,9 +130,11 @@ class ReadFiles:
                     curr_len = 0
 
                 for i, chunk_part in enumerate(split_line(line)):
-                    if i > 0 and chunk_text:
+                    if chunk_text:
                         chunk_part = add_overlap(
-                            chunk_text[-1], chunk_part, separator=""
+                            chunk_text[-1],
+                            chunk_part,
+                            separator='\n' if i == 0 else '',
                         )
                     chunk_text.append(chunk_part)
 

--- a/docs/chapter7/RAG/utils.py
+++ b/docs/chapter7/RAG/utils.py
@@ -68,86 +68,96 @@ class ReadFiles:
             )
 
         chunk_text = []
+        token_len = max_token_len - cover_content
+
+        def split_line(line: str) -> list[str]:
+            """按完整 Unicode 字符切分，并优先遵守新增内容预算。"""
+            parts = []
+            start = 0
+            while start < len(line):
+                best_end = None
+                for end in range(start + 1, len(line) + 1):
+                    if len(enc.encode(line[start:end])) <= token_len:
+                        best_end = end
+                    else:
+                        break
+                if best_end is None:
+                    for end in range(start + 1, len(line) + 1):
+                        if len(enc.encode(line[start:end])) <= max_token_len:
+                            best_end = end
+                        else:
+                            break
+                if best_end is None:
+                    raise ValueError(
+                        "单个 Unicode 字符的 Token 数超过 max_token_len"
+                    )
+                parts.append(line[start:best_end])
+                start = best_end
+            return parts
+
+        def add_overlap(previous: str, payload: str, separator: str) -> str:
+            """从完整字符边界提取重叠，并确保最终片段不超过总预算。"""
+            if not cover_content:
+                return payload
+            overlap = ""
+            for start in range(len(previous) - 1, -1, -1):
+                candidate = previous[start:]
+                if len(enc.encode(candidate)) <= cover_content:
+                    overlap = candidate
+                else:
+                    break
+            while overlap:
+                candidate = overlap + separator + payload
+                if len(enc.encode(candidate)) <= max_token_len:
+                    return candidate
+                overlap = overlap[1:]
+            return payload
 
         curr_len = 0
         curr_chunk = ''
-
-        token_len = max_token_len - cover_content
         lines = text.splitlines()  # 假设以换行符分割文本为行
 
         for line in lines:
             # 保留空格，只移除行首行尾空格
             line = line.strip()
             line_len = len(enc.encode(line))
-            
+
             if line_len > token_len:
-                # 如果单行长度就超过限制，则将其分割成多个块
-                # 先保存当前块（如果有内容）
+                # 如果单行长度就超过新增内容预算，则按完整字符切分
                 if curr_chunk:
                     chunk_text.append(curr_chunk)
                     curr_chunk = ''
                     curr_len = 0
-                
-                # 将长行按token长度分割
-                line_tokens = enc.encode(line)
-                num_chunks = (len(line_tokens) + token_len - 1) // token_len
-                
-                for i in range(num_chunks):
-                    start_token = i * token_len
-                    end_token = min(start_token + token_len, len(line_tokens))
-                    
-                    # 解码token片段回文本
-                    chunk_tokens = line_tokens[start_token:end_token]
-                    chunk_part = enc.decode(chunk_tokens)
-                    
-                    # 添加覆盖内容（除了第一个块）
+
+                for i, chunk_part in enumerate(split_line(line)):
                     if i > 0 and chunk_text:
-                        prev_chunk = chunk_text[-1]
-                        prev_tokens = enc.encode(prev_chunk)
-                        cover_tokens = (
-                            prev_tokens[-cover_content:]
-                            if cover_content
-                            else []
+                        chunk_part = add_overlap(
+                            chunk_text[-1], chunk_part, separator=""
                         )
-                        cover_part = enc.decode(cover_tokens)
-                        chunk_part = cover_part + chunk_part
-                    
                     chunk_text.append(chunk_part)
-                
-                # 重置当前块状态
+
                 curr_chunk = ''
                 curr_len = 0
-                
+
             elif curr_len + line_len + (1 if curr_chunk else 0) <= token_len:
-                # 当前行可以加入当前块
                 if curr_chunk:
                     curr_chunk += '\n'
                     curr_len += 1
                 curr_chunk += line
                 curr_len += line_len
             else:
-                # 当前行无法加入当前块，开始新块
                 if curr_chunk:
                     chunk_text.append(curr_chunk)
-                
-                # 开始新块，添加覆盖内容
+
                 if chunk_text:
-                    prev_chunk = chunk_text[-1]
-                    prev_tokens = enc.encode(prev_chunk)
-                    cover_tokens = (
-                        prev_tokens[-cover_content:]
-                        if cover_content
-                        else []
+                    curr_chunk = add_overlap(
+                        chunk_text[-1], line, separator='\n'
                     )
-                    cover_part = enc.decode(cover_tokens)
-                    curr_chunk = cover_part + '\n' + line
-                    # curr_len 只记录新增内容；重叠内容已有独立预算。
-                    curr_len = 1 + line_len
+                    curr_len = line_len + (1 if curr_chunk != line else 0)
                 else:
                     curr_chunk = line
                     curr_len = line_len
 
-        # 添加最后一个块（如果有内容）
         if curr_chunk:
             chunk_text.append(curr_chunk)
 

--- a/docs/chapter7/RAG/utils.py
+++ b/docs/chapter7/RAG/utils.py
@@ -59,6 +59,14 @@ class ReadFiles:
 
     @classmethod
     def get_chunk(cls, text: str, max_token_len: int = 600, cover_content: int = 150):
+        if max_token_len <= 0:
+            raise ValueError("max_token_len must be greater than 0")
+        if cover_content < 0 or cover_content >= max_token_len:
+            raise ValueError(
+                "cover_content must be greater than or equal to 0 "
+                "and less than max_token_len"
+            )
+
         chunk_text = []
 
         curr_len = 0
@@ -72,7 +80,7 @@ class ReadFiles:
             line = line.strip()
             line_len = len(enc.encode(line))
             
-            if line_len > max_token_len:
+            if line_len > token_len:
                 # 如果单行长度就超过限制，则将其分割成多个块
                 # 先保存当前块（如果有内容）
                 if curr_chunk:
@@ -95,7 +103,13 @@ class ReadFiles:
                     # 添加覆盖内容（除了第一个块）
                     if i > 0 and chunk_text:
                         prev_chunk = chunk_text[-1]
-                        cover_part = prev_chunk[-cover_content:] if len(prev_chunk) > cover_content else prev_chunk
+                        prev_tokens = enc.encode(prev_chunk)
+                        cover_tokens = (
+                            prev_tokens[-cover_content:]
+                            if cover_content
+                            else []
+                        )
+                        cover_part = enc.decode(cover_tokens)
                         chunk_part = cover_part + chunk_part
                     
                     chunk_text.append(chunk_part)
@@ -104,7 +118,7 @@ class ReadFiles:
                 curr_chunk = ''
                 curr_len = 0
                 
-            elif curr_len + line_len + 1 <= token_len:  # +1 for newline
+            elif curr_len + line_len + (1 if curr_chunk else 0) <= token_len:
                 # 当前行可以加入当前块
                 if curr_chunk:
                     curr_chunk += '\n'
@@ -119,9 +133,16 @@ class ReadFiles:
                 # 开始新块，添加覆盖内容
                 if chunk_text:
                     prev_chunk = chunk_text[-1]
-                    cover_part = prev_chunk[-cover_content:] if len(prev_chunk) > cover_content else prev_chunk
+                    prev_tokens = enc.encode(prev_chunk)
+                    cover_tokens = (
+                        prev_tokens[-cover_content:]
+                        if cover_content
+                        else []
+                    )
+                    cover_part = enc.decode(cover_tokens)
                     curr_chunk = cover_part + '\n' + line
-                    curr_len = len(enc.encode(cover_part)) + 1 + line_len
+                    # curr_len 只记录新增内容；重叠内容已有独立预算。
+                    curr_len = 1 + line_len
                 else:
                     curr_chunk = line
                     curr_len = line_len

--- a/docs/chapter7/第七章 大模型应用.md
+++ b/docs/chapter7/第七章 大模型应用.md
@@ -230,9 +230,11 @@ def get_chunk(cls, text: str, max_token_len: int = 600, cover_content: int = 150
                 curr_len = 0
 
             for i, chunk_part in enumerate(split_line(line)):
-                if i > 0 and chunk_text:
+                if chunk_text:
                     chunk_part = add_overlap(
-                        chunk_text[-1], chunk_part, separator=""
+                        chunk_text[-1],
+                        chunk_part,
+                        separator='\n' if i == 0 else '',
                     )
                 chunk_text.append(chunk_part)
 
@@ -267,7 +269,8 @@ def get_chunk(cls, text: str, max_token_len: int = 600, cover_content: int = 150
 这里的 `cover_content` 与 `max_token_len` 都以 Token 为单位。每次从前一个片段的
 末尾按完整 Unicode 字符选择不超过 `cover_content` Token 的重叠内容；如果单个
 字符超过新增内容预算，则缩减重叠并使用总预算，避免拆分字符。`curr_len` 只累计
-新加入的内容，因为重叠部分已经由 `cover_content` 单独预留。
+新加入的内容，因为重叠部分已经由 `cover_content` 单独预留。普通短行后紧接长行
+时，长行的首个子片段也会继承前一个片段的重叠内容，避免在这种混合边界丢失上下文。
 
 #### Step 3: 向量化
 

--- a/docs/chapter7/第七章 大模型应用.md
+++ b/docs/chapter7/第七章 大模型应用.md
@@ -159,6 +159,14 @@ def read_file_content(cls, file_path: str):
 
 ```python
 def get_chunk(cls, text: str, max_token_len: int = 600, cover_content: int = 150):
+    if max_token_len <= 0:
+        raise ValueError("max_token_len must be greater than 0")
+    if cover_content < 0 or cover_content >= max_token_len:
+        raise ValueError(
+            "cover_content must be greater than or equal to 0 "
+            "and less than max_token_len"
+        )
+
     chunk_text = []
 
     curr_len = 0
@@ -172,7 +180,7 @@ def get_chunk(cls, text: str, max_token_len: int = 600, cover_content: int = 150
         line = line.strip()
         line_len = len(enc.encode(line))
         
-        if line_len > max_token_len:
+        if line_len > token_len:
             # 如果单行长度就超过限制，则将其分割成多个块
             # 先保存当前块（如果有内容）
             if curr_chunk:
@@ -195,7 +203,13 @@ def get_chunk(cls, text: str, max_token_len: int = 600, cover_content: int = 150
                 # 添加覆盖内容（除了第一个块）
                 if i > 0 and chunk_text:
                     prev_chunk = chunk_text[-1]
-                    cover_part = prev_chunk[-cover_content:] if len(prev_chunk) > cover_content else prev_chunk
+                    prev_tokens = enc.encode(prev_chunk)
+                    cover_tokens = (
+                        prev_tokens[-cover_content:]
+                        if cover_content
+                        else []
+                    )
+                    cover_part = enc.decode(cover_tokens)
                     chunk_part = cover_part + chunk_part
                 
                 chunk_text.append(chunk_part)
@@ -204,7 +218,7 @@ def get_chunk(cls, text: str, max_token_len: int = 600, cover_content: int = 150
             curr_chunk = ''
             curr_len = 0
             
-        elif curr_len + line_len + 1 <= token_len:  # +1 for newline
+        elif curr_len + line_len + (1 if curr_chunk else 0) <= token_len:
             # 当前行可以加入当前块
             if curr_chunk:
                 curr_chunk += '\n'
@@ -219,9 +233,16 @@ def get_chunk(cls, text: str, max_token_len: int = 600, cover_content: int = 150
             # 开始新块，添加覆盖内容
             if chunk_text:
                 prev_chunk = chunk_text[-1]
-                cover_part = prev_chunk[-cover_content:] if len(prev_chunk) > cover_content else prev_chunk
+                prev_tokens = enc.encode(prev_chunk)
+                cover_tokens = (
+                    prev_tokens[-cover_content:]
+                    if cover_content
+                    else []
+                )
+                cover_part = enc.decode(cover_tokens)
                 curr_chunk = cover_part + '\n' + line
-                curr_len = len(enc.encode(cover_part)) + 1 + line_len
+                # curr_len 只记录新增内容；重叠内容已有独立预算。
+                curr_len = 1 + line_len
             else:
                 curr_chunk = line
                 curr_len = line_len
@@ -233,6 +254,10 @@ def get_chunk(cls, text: str, max_token_len: int = 600, cover_content: int = 150
     return chunk_text
 
 ```
+
+这里的 `cover_content` 与 `max_token_len` 都以 Token 为单位。每次从前一个片段的
+Token 序列末尾提取重叠内容；`curr_len` 只累计新加入的内容，因为重叠部分已经由
+`cover_content` 单独预留。
 
 #### Step 3: 向量化
 

--- a/docs/chapter7/第七章 大模型应用.md
+++ b/docs/chapter7/第七章 大模型应用.md
@@ -155,7 +155,7 @@ def read_file_content(cls, file_path: str):
         raise ValueError("Unsupported file type")
 ```
 
-文档读取后需要进行切分。我们可以设置一个最大的Token长度，然后根据这个最大长度来切分文档。切分文档时最好以句子为单位（按`\n`粗切分），并保证片段之间有一些重叠内容，以提高检索的准确性。
+文档读取后需要进行切分。我们可以设置一个最大的Token长度，然后根据这个最大长度来切分文档。切分文档时最好以句子为单位（按`\n`粗切分），并保证片段之间有一些重叠内容，以提高检索的准确性。切分点应落在完整 Unicode 字符边界上，避免任意 Token 子序列解码损坏 Emoji 或扩展字符。
 
 ```python
 def get_chunk(cls, text: str, max_token_len: int = 600, cover_content: int = 150):
@@ -168,96 +168,106 @@ def get_chunk(cls, text: str, max_token_len: int = 600, cover_content: int = 150
         )
 
     chunk_text = []
+    token_len = max_token_len - cover_content
+
+    def split_line(line: str) -> list[str]:
+        """按完整 Unicode 字符切分，并优先遵守新增内容预算。"""
+        parts = []
+        start = 0
+        while start < len(line):
+            best_end = None
+            for end in range(start + 1, len(line) + 1):
+                if len(enc.encode(line[start:end])) <= token_len:
+                    best_end = end
+                else:
+                    break
+            if best_end is None:
+                for end in range(start + 1, len(line) + 1):
+                    if len(enc.encode(line[start:end])) <= max_token_len:
+                        best_end = end
+                    else:
+                        break
+            if best_end is None:
+                raise ValueError(
+                    "单个 Unicode 字符的 Token 数超过 max_token_len"
+                )
+            parts.append(line[start:best_end])
+            start = best_end
+        return parts
+
+    def add_overlap(previous: str, payload: str, separator: str) -> str:
+        """从完整字符边界提取重叠，并确保最终片段不超过总预算。"""
+        if not cover_content:
+            return payload
+        overlap = ""
+        for start in range(len(previous) - 1, -1, -1):
+            candidate = previous[start:]
+            if len(enc.encode(candidate)) <= cover_content:
+                overlap = candidate
+            else:
+                break
+        while overlap:
+            candidate = overlap + separator + payload
+            if len(enc.encode(candidate)) <= max_token_len:
+                return candidate
+            overlap = overlap[1:]
+        return payload
 
     curr_len = 0
     curr_chunk = ''
-
-    token_len = max_token_len - cover_content
     lines = text.splitlines()  # 假设以换行符分割文本为行
 
     for line in lines:
         # 保留空格，只移除行首行尾空格
         line = line.strip()
         line_len = len(enc.encode(line))
-        
+
         if line_len > token_len:
-            # 如果单行长度就超过限制，则将其分割成多个块
-            # 先保存当前块（如果有内容）
+            # 如果单行长度就超过新增内容预算，则按完整字符切分
             if curr_chunk:
                 chunk_text.append(curr_chunk)
                 curr_chunk = ''
                 curr_len = 0
-            
-            # 将长行按token长度分割
-            line_tokens = enc.encode(line)
-            num_chunks = (len(line_tokens) + token_len - 1) // token_len
-            
-            for i in range(num_chunks):
-                start_token = i * token_len
-                end_token = min(start_token + token_len, len(line_tokens))
-                
-                # 解码token片段回文本
-                chunk_tokens = line_tokens[start_token:end_token]
-                chunk_part = enc.decode(chunk_tokens)
-                
-                # 添加覆盖内容（除了第一个块）
+
+            for i, chunk_part in enumerate(split_line(line)):
                 if i > 0 and chunk_text:
-                    prev_chunk = chunk_text[-1]
-                    prev_tokens = enc.encode(prev_chunk)
-                    cover_tokens = (
-                        prev_tokens[-cover_content:]
-                        if cover_content
-                        else []
+                    chunk_part = add_overlap(
+                        chunk_text[-1], chunk_part, separator=""
                     )
-                    cover_part = enc.decode(cover_tokens)
-                    chunk_part = cover_part + chunk_part
-                
                 chunk_text.append(chunk_part)
-            
-            # 重置当前块状态
+
             curr_chunk = ''
             curr_len = 0
-            
+
         elif curr_len + line_len + (1 if curr_chunk else 0) <= token_len:
-            # 当前行可以加入当前块
             if curr_chunk:
                 curr_chunk += '\n'
                 curr_len += 1
             curr_chunk += line
             curr_len += line_len
         else:
-            # 当前行无法加入当前块，开始新块
             if curr_chunk:
                 chunk_text.append(curr_chunk)
-            
-            # 开始新块，添加覆盖内容
+
             if chunk_text:
-                prev_chunk = chunk_text[-1]
-                prev_tokens = enc.encode(prev_chunk)
-                cover_tokens = (
-                    prev_tokens[-cover_content:]
-                    if cover_content
-                    else []
+                curr_chunk = add_overlap(
+                    chunk_text[-1], line, separator='\n'
                 )
-                cover_part = enc.decode(cover_tokens)
-                curr_chunk = cover_part + '\n' + line
-                # curr_len 只记录新增内容；重叠内容已有独立预算。
-                curr_len = 1 + line_len
+                curr_len = line_len + (1 if curr_chunk != line else 0)
             else:
                 curr_chunk = line
                 curr_len = line_len
 
-    # 添加最后一个块（如果有内容）
     if curr_chunk:
         chunk_text.append(curr_chunk)
 
     return chunk_text
-
 ```
 
 这里的 `cover_content` 与 `max_token_len` 都以 Token 为单位。每次从前一个片段的
-Token 序列末尾提取重叠内容；`curr_len` 只累计新加入的内容，因为重叠部分已经由
-`cover_content` 单独预留。
+末尾按完整 Unicode 字符选择不超过 `cover_content` Token 的重叠内容；如果单个
+字符超过新增内容预算，则缩减重叠并使用总预算，避免拆分字符。`curr_len` 只累计
+新加入的内容，因为重叠部分已经由 `cover_content` 单独预留。
 
 #### Step 3: 向量化
 


### PR DESCRIPTION
## 问题

`ReadFiles.get_chunk()` 的 `cover_content` 表示 Token 数，但原实现用
`prev_chunk[-cover_content:]` 按字符截取重叠内容。对于中文等一个字符可能对应多个
Token 的文本，最终片段会超过 `max_token_len`。

同时，普通多行分支把重叠 Token 再次计入 `curr_len`，而
`token_len = max_token_len - cover_content` 已经为重叠预留预算，导致后续片段提前
切分、容量利用不足。

增量审计还发现，按 Token ID 任意切片后直接调用 `enc.decode()` 会在切点落入 UTF-8
字符内部时使用 `U+FFFD` 替换无效字节，静默损坏 Emoji 或扩展字符。

Refs #128

## 最小复现

使用仓库锁定的 `tiktoken==0.9.0`：

- `"你好世界" * 30`，`max_token_len=20`、`cover_content=5`：
  修复前后续片段为 21 Tokens，超过上限。
- 四行 `alpha`，`max_token_len=6`、`cover_content=2`：
  修复前产生 3 个片段，第二个片段只有 3 Tokens。
- `"😊"`，`max_token_len=2`、`cover_content=1`：
  该字符编码为 `[76460, 232]`，修复前按单 Token 切片后得到 `['�', '��']`；
  修复后得到 `['😊']`，没有替换字符且片段仍为 2 Tokens。

`tiktoken 0.9.0` 的 `Encoding.decode()` 源码明确说明默认解码可能有损，因为任意
Token 边界不保证与 UTF-8 字符边界一致：
https://github.com/openai/tiktoken/blob/0.9.0/tiktoken/core.py

## 改动

- 按完整 Unicode 字符构造长行 payload，并以实际 Token 数选择切点。
- 优先遵守新增内容预算；如果单个字符超过该预算，则最多放宽到总预算，并缩减重叠。
- 从完整字符后缀提取不超过 `cover_content` Token 的重叠内容。
- 对重叠与 payload 的最终组合重新编码，确保不超过 `max_token_len`。
- `curr_len` 只累计新增内容，不重复占用重叠预算。
- 拒绝非正上限、负重叠和 `cover_content >= max_token_len`。
- 同步第七章正文代码、Token 单位和 Unicode 边界说明。
- 新增无网络回归测试，覆盖中文长行、多行容量、非法预算和 Unicode 边界。

## 验证

环境：

- macOS arm64
- Python 3.10.20
- `tiktoken==0.9.0`
- `PyPDF2==3.0.1`
- `markdown==3.8.2`
- `tqdm==4.67.1`
- `beautifulsoup4==4.13.4`

```bash
PYTHONDONTWRITEBYTECODE=1 \
PYTHONPATH=.deps:docs/chapter7/RAG \
python3 -m unittest discover -s docs/chapter7/RAG -p 'test_*.py' -v

python3 -m py_compile \
  docs/chapter7/RAG/utils.py \
  docs/chapter7/RAG/test_utils.py

ruff check docs/chapter7/RAG/test_utils.py
git diff --check
```

结果：5 个测试全部通过；语法、测试文件静态检查和差异检查通过。中文长行片段
Token 数保持 `[15, 20, 20, ...]`，四行样例保持 2 个片段、Token 数 `[3, 6]`；
Emoji、连续 Emoji 与 CJK 扩展字符 smoke test 均无 `U+FFFD`，所有片段不超过上限。

## 验证限制

仓库 Chapter 7 完整 `requirements.txt` 当前锁定 `numpy==2.3.0`，该版本要求
Python 3.11+，因此无法在本机 Python 3.10.20 下完整安装。本次安装并验证了
`utils.py` 实际导入所需的上述依赖，其中分块行为使用仓库指定的
`tiktoken==0.9.0`；测试不调用 LLM、Embedding 或外部 API。

`utils.py` 既有未使用 import 会导致对整个文件执行 `ruff check` 失败；本 PR 未扩大
范围清理，新增测试文件单独通过 Ruff。

当前 head 没有 GitHub check run、commit status 或分支 Actions run；这是无 CI
checks，不是 CI 通过。

## 2026-08-31 混合行边界修复（7b8a541）

- 增量复现确认：普通短行后紧接需要切分的长行时，原实现先提交短行，但仅在 `i > 0` 时给长行子片段加 overlap，因此短行与长行首片段之间完全丢失上下文重叠。
- 固定输入 `alpha\n + 你好世界 * 20`、`max_token_len=10`、`cover_content=2`：旧 head 的前两片段为 `alpha` 与 `你好世界你好`，第二片段不含前文；修复后为 `alpha` 与 `alpha\n你好世界你好`，第二片段 9 Tokens。
- 现对所有已有前序片段的长行子片段添加 overlap：长行首片段使用换行分隔，长行内部片段保持无分隔拼接；最终组合仍由 `add_overlap()` 重新编码并限制在总预算内。
- 新增 `test_overlap_is_kept_before_first_part_of_long_line`，同步第七章正文代码与边界说明。Python 3.10.20、锁定依赖下 5 项测试、Emoji/CJK smoke、`py_compile`、测试文件 `ruff check`、`git diff --check`、`git show --check` 全部通过。